### PR TITLE
Added socioeconomic status and tried to fix a comma splice

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Contributors to this Code of Conduct are [listed here](https://github.com/cville
 
 ## Anti-harassment Policy
 
-Harassment includes verbal comments that reinforce social structures of domination -- related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
+Harassment includes verbal comments that reinforce social structures of domination -- related to gender, gender identity and expression, sexual orientation, disability, physical appearance, body size, race, age, religion, or socioeconomic status -- as well as sexual images in public spaces, deliberate intimidation, stalking, following, harassing photography or recording, sustained disruption of talks or other events, inappropriate physical contact, and unwelcome sexual attention. Participants asked to stop any harassing behavior are expected to comply immediately.
 
 If a participant engages in harassing behavior, the organizers may take any action they deem appropriate, including warning the offender or expulsion from the group. If you are being harassed, notice that someone else is being harassed, or have any other concerns, please contact organizers immediately.
 


### PR DESCRIPTION
Not really a substantive change; the list in the long version was hard to parse. (It is hard to parse in the Geek Feminism version, too; I really should go in and fix that for them.) Also, we added "socioeconomic status" to the short version, so I added it to the long version. Thanks!
