### PR TITLE
Use SPLC designations for hate groups.

### DIFF
--- a/README.md
+++ b/README.md
@@ -230,8 +230,14 @@ Following the previous section, find consensus with other organizers to remove a
 * compromises others' health or safety
 * has repeat issues or patterns of misconduct
 * engages in unconscionable behavior
-* is identified to be a participant in a hate group
+* is identified to participate in a [SPLC-designated](https://www.splcenter.org/hate-map) hate group
 * exhibits _any reason_ that causes organizers serious concern
+
+The code of conduct uses Southern Poverty Law Center (SPLC) designations because its definition of a hate group aligns with the intent of the code of conduct:
+
+> *What is a hate group?*
+>
+> The SPLC defines a hate group as an organization that – based on its official statements or principles, the statements of its leaders, or its activities – has beliefs or practices that attack or malign an entire class of people, typically for their immutable characteristics.
 
 
 ### When misconduct is public


### PR DESCRIPTION
Re: #19, we would like to avoid ambiguity on what counts as a "hate group." These changes adopt the SPLC designation. We seek to strike a balance between:

* Being clear that participation in a hate group is enough to raise concerns.
* Using a clear designation on what constitutes a hate group.
* Use hate group designations without adopting political views.

I wrote _why_ SPLC's designations are used to support this balance.